### PR TITLE
Update folder names for stages

### DIFF
--- a/Management/CustomMusicManager.cs
+++ b/Management/CustomMusicManager.cs
@@ -93,9 +93,9 @@ namespace NickCustomMusicMod.Management
 		}
 
 		public static string UpdateOldFormatAndGetName(string folderPath) {
-			var folderName = Path.GetFileName(directory);
+			var folderName = Path.GetFileName(folderPath);
 			if (Consts.StageIDs.ContainsValue(folderName)) {
-				string updatedStageName = types.FirstOrDefault(x => x.Value == folderPath).Key;
+				string updatedStageName = StageIDs.FirstOrDefault(x => x.Value == folderPath).Key;
 				string updatedFolderPath = Path.Combine(Directory.GetParent(folderPath), updatedStageName);
 
 				Directory.Move(folderPath, updatedFolderPath);

--- a/Management/CustomMusicManager.cs
+++ b/Management/CustomMusicManager.cs
@@ -98,8 +98,19 @@ namespace NickCustomMusicMod.Management
 				string updatedStageName = Consts.StageIDs.FirstOrDefault(x => x.Value == folderPath).Key;
 				string updatedFolderPath = Path.Combine(Directory.GetParent(folderPath), updatedStageName);
 
-				Directory.Move(folderPath, updatedFolderPath);
-				return updatedStageName;
+				try {
+					Directory.Move(folderPath, updatedFolderPath);
+					return updatedStageName;
+				} catch (IOException ex){
+					Plugin.LogInfo($"Failed to rename old folder {folderName} to {updatedStageName}.");
+					Plugin.LogInfo($"Does the directory already exist?");
+					Plugin.LogError($"Exception {ex.Message}");
+				}
+				catch (Exception ex)
+				{
+					Plugin.LogInfo($"Failed to rename old folder {folderName} to {updatedStageName}.");
+					Plugin.LogError($"Exception {ex.Message}");
+				}
 			}
 			return folderName;
 		}

--- a/Management/CustomMusicManager.cs
+++ b/Management/CustomMusicManager.cs
@@ -102,17 +102,46 @@ namespace NickCustomMusicMod.Management
 					Directory.Move(folderPath, updatedFolderPath);
 					return updatedStageName;
 				} catch (IOException ex){
-					Plugin.LogInfo($"Failed to rename old folder {folderName} to {updatedStageName}.");
-					Plugin.LogInfo($"Does the directory already exist?");
-					Plugin.LogError($"Exception {ex.Message}");
+					Plugin.LogInfo($"Could not rename directory! Maybe the new directory already exists?");
+					Plugin.LogInfo($"Attempting to copy files from \"{folderName}\" to \"{updatedStageName}\" instead.");
+					CopyFilesAndDeleteOriginalFolder(folderPath, updatedFolderPath);
 				}
 				catch (Exception ex)
 				{
-					Plugin.LogInfo($"Failed to rename old folder {folderName} to {updatedStageName}.");
+					Plugin.LogError($"Failed to rename old folder \"{folderName}\" to \"{updatedStageName}\"!");
 					Plugin.LogError($"Exception {ex.Message}");
 				}
 			}
 			return folderName;
+		}
+
+		public static bool CopyFilesAndDeleteOriginalFolder(string originalDirPath, string targetDirPath) {
+			string[] files = Directory.GetFiles(originalDirPath);
+
+			try {
+				// Copy the files and overwrite destination files if they already exist.
+				foreach (string filePath in files)
+				{
+					fileName = Path.GetFileName(filePath);
+					destPath = Path.Combine(targetDirPath, fileName);
+					File.Copy(filePath, destPath, true);
+				}
+
+				try {
+					// Delete og folder copying files
+					Directory.Delete(originalDirPath, true);
+				} catch(Exception ex) {
+					Plugin.LogError($"Failed to delete original folder \"{originalDirPath}\"!");
+					Plugin.LogError($"Exception {ex.Message}");
+					return false;
+				}
+			} catch(Exception ex) {
+				Plugin.LogError($"Failed to copy files from folder \"{originalDirPath}\" to \"{targetDirPath}\"!");
+				Plugin.LogError($"Exception {ex.Message}");
+				return false;
+			}
+
+			return true;
 		}
 
 		internal static Dictionary<string, Dictionary<string, MusicItem>> songDictionaries;

--- a/Management/CustomMusicManager.cs
+++ b/Management/CustomMusicManager.cs
@@ -96,7 +96,7 @@ namespace NickCustomMusicMod.Management
 			var folderName = Path.GetFileName(folderPath);
 			if (Consts.StageIDs.ContainsValue(folderName)) {
 				string updatedStageName = Consts.StageIDs.FirstOrDefault(x => x.Value == folderPath).Key;
-				string updatedFolderPath = Path.Combine(Directory.GetParent(folderPath), updatedStageName);
+				string updatedFolderPath = Path.Combine(Directory.GetParent(folderPath).Name, updatedStageName);
 
 				try {
 					Directory.Move(folderPath, updatedFolderPath);

--- a/Management/CustomMusicManager.cs
+++ b/Management/CustomMusicManager.cs
@@ -49,7 +49,7 @@ namespace NickCustomMusicMod.Management
 
 			foreach (string directory in subDirectories)
 			{
-				var directoryName = Path.GetFileName(directory);
+				var directoryName = UpdateOldFormatAndGetName(directory);
 
 				Plugin.LogDebug($"directory {directoryName} full path {directory}");
 				LoadSongsFromFolder(parentFolderName, directoryName);
@@ -88,6 +88,18 @@ namespace NickCustomMusicMod.Management
 		public static string TranslateFolderNameToID(string folderName) {
 			if (Consts.StageIDs.ContainsKey(folderName)) {
 				return Consts.StageIDs[folderName];
+			}
+			return folderName;
+		}
+
+		public static string UpdateOldFormatAndGetName(string folderPath) {
+			var folderName = Path.GetFileName(directory);
+			if (Consts.StageIDs.ContainsValue(folderName)) {
+				string updatedStageName = types.FirstOrDefault(x => x.Value == folderPath).Key;
+				string updatedFolderPath = Path.Combine(Directory.GetParent(folderPath), updatedStageName);
+
+				Directory.Move(folderPath, updatedFolderPath);
+				return updatedStageName;
 			}
 			return folderName;
 		}

--- a/Management/CustomMusicManager.cs
+++ b/Management/CustomMusicManager.cs
@@ -26,7 +26,11 @@ namespace NickCustomMusicMod.Management
 				// Create the folder if it doesn't exist
 				Directory.CreateDirectory(rootCustomSongsPath);
 
-				// Generate folders, incase any were deleted
+				// Load songs
+				LoadFromSubDirectories("Stages");
+				LoadFromSubDirectories("Menus");
+
+				// Generate folders, incase any don't exist 
 				foreach (string menuID in Consts.MenuIDs)
 				{
 					Directory.CreateDirectory(Path.Combine(rootCustomSongsPath, "Menus", menuID));
@@ -36,10 +40,6 @@ namespace NickCustomMusicMod.Management
 				{
 					Directory.CreateDirectory(Path.Combine(rootCustomSongsPath, "Stages", stageName));
 				}
-
-				// Load songs
-				LoadFromSubDirectories("Stages");
-				LoadFromSubDirectories("Menus");
 			});
         }
 

--- a/Management/CustomMusicManager.cs
+++ b/Management/CustomMusicManager.cs
@@ -95,7 +95,7 @@ namespace NickCustomMusicMod.Management
 		public static string UpdateOldFormatAndGetName(string folderPath) {
 			var folderName = Path.GetFileName(folderPath);
 			if (Consts.StageIDs.ContainsValue(folderName)) {
-				string updatedStageName = StageIDs.FirstOrDefault(x => x.Value == folderPath).Key;
+				string updatedStageName = Consts.StageIDs.FirstOrDefault(x => x.Value == folderPath).Key;
 				string updatedFolderPath = Path.Combine(Directory.GetParent(folderPath), updatedStageName);
 
 				Directory.Move(folderPath, updatedFolderPath);

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Developers may be interested in this reference for the music IDs in game.
 | Glove World | CarnivalLofi |
 | Harmonic Convergence | SpiritWorld |
 | Irken Armada Invasion | Armada |
+| Jellyfish Fields | SlideHouse |
 | Omashu | Omashu |
 | Powdered Toast Trouble | DuoKitchen |
 | Rooftop Rumble | Rooftop |
@@ -65,7 +66,6 @@ Developers may be interested in this reference for the music IDs in game.
 | The Dump | Trash |
 | The Flying Dutchman's Ship | Shanty |
 | The Loud House | Loud |
-| Jellyfish Fields | SlideHouse |
 | Traffic Jam | Stomp |
 | Western Air Temple | Temple2 |
 | Wild Waterfall | Waterfall |

--- a/README.md
+++ b/README.md
@@ -32,50 +32,50 @@ BepInEx
             ↳ LoseV1
               ...
         ↳ Stages
-            ↳ Armada
-            ↳ CarnivalLofi
+            ↳ CatDog's House
+            ↳ Glove World
               ...
 ```
 
 Place `.wav`, `.ogg`, or `.mp3` files into the folder corresponding to the stage or menu you want to change.
 
-For example, if you want to use a different song for the Jellyfish Fields stage, place the audio file in `BepInEx\CustomSongs\Stages\SlideHouse`
+For example, if you want to use a different song for the Jellyfish Fields stage, place the audio file in `BepInEx\CustomSongs\Stages\Jellyfish Fields`
 
 If multiple audio files are in the same folder, one is randomly selected each time that stage / menu is loaded!
 
-The folder names correspond to the ingame ID for each stage / menu. Some of them have confusing names! See the list below.
+# Reference
 
-Stages
-```
-Armada --------- Irken Armada Invasion
-CarnivalLofi --- Glove World
-Drome ---------- Technodrom Takedown
-DuoKitchen ----- Powdered Toast Trouble
-DuoMadness ----- Space Madness
-House ---------- CatDog's House
-Loud ----------- The Loud House
-Omashu --------- Omashu
-Playground ----- Showdown at Teeter Totter Gulch
-Rooftop -------- Rooftop Rumble
-SewersCombined - Sewers Slam
-Shanty --------- The Flying Dutchman's Ship
-SlideHouse ----- Jellyfish Fields
-SpiritWorld ---- Harmonic Convergence
-Stomp ---------- Traffic Jam
-Temple2 -------- Western Air Temple
-Trash ---------- The Dump
-Waterfall ------ Wild Waterfall
-YMC ------------ Royal Woods Cemetery
-Zone ----------- Ghost Zone
-```
+Deveopers maybe be interested in this reference for the music IDs in game.
 
-Menus
-```
-ArcadeMap ----
-LoseV1 ------- 
-LoseV2 ------- Not sure why there are two of these yet
-MainMenu -----
-OnlineMenu --- The MainMenu music tends to override this
-Versus -------
-Victory ------
-```
+| Stage Name | Stage ID |
+|----------|--------|
+| CatDog's House | House |
+| Ghost Zone | Zone |
+| Glove World | CarnivalLofi |
+| Harmonic Convergence | SpiritWorld |
+| Irken Armada Invasion | Armada |
+| Omashu | Omashu |
+| Powdered Toast Trouble | DuoKitchen |
+| Rooftop Rumble | Rooftop |
+| Royal Woods Cemetery | YMC |
+| Sewers Slam | SewersCombined |
+| Showdown at Teeter Totter Gulch | Playground |
+| Space Madness | DuoMadness |
+| Technodrom Takedown | Drome |
+| The Dump | Trash |
+| The Flying Dutchman's Ship | Shanty |
+| The Loud House | Loud |
+| Jellyfish Fields | SlideHouse |
+| Traffic Jam | Stomp |
+| Western Air Temple | Temple2 |
+| Wild Waterfall | Waterfall |
+
+| Menu Name | Notes |
+|-----------|-------|
+| ArcadeMap | Menu music played when you enter the Arcade mode menu|
+| LoseV1 | |
+| LoseV2 | Not sure why there are two of these yet
+| MainMenu | Main menu music! |
+| OnlineMenu | The MainMenu music tends to override this
+| Versus | The "VS" text screen before match starts |
+| Victory | End of match victory screen|

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If multiple audio files are in the same folder, one is randomly selected each ti
 
 # Reference
 
-Deveopers maybe be interested in this reference for the music IDs in game.
+Developers may be interested in this reference for the music IDs in game.
 
 | Stage Name | Stage ID |
 |----------|--------|
@@ -74,8 +74,8 @@ Deveopers maybe be interested in this reference for the music IDs in game.
 |-----------|-------|
 | ArcadeMap | Menu music played when you enter the Arcade mode menu|
 | LoseV1 | |
-| LoseV2 | Not sure why there are two of these yet
+| LoseV2 | Not sure why there are two of these yet |
 | MainMenu | Main menu music! |
-| OnlineMenu | The MainMenu music tends to override this
+| OnlineMenu | The MainMenu music tends to override this |
 | Versus | The "VS" text screen before match starts |
 | Victory | End of match victory screen|

--- a/Utils/Consts.cs
+++ b/Utils/Consts.cs
@@ -4,32 +4,31 @@ using System.Text;
 
 namespace NickCustomMusicMod.Utils
 {
-    // These should really be loaded from the game, not from a stored list, but
-    // this list simply dictates which folders are auto generated.
-    // Currently the mod will also load files from any extra subfolder in the "Stage" or "Menu" folders,
-    // incase extra stages are added in the future.
+    // This list dictates which folders are auto generated
+    // It also translates the folder names to their in game ID
     public static class Consts
     {
         public static readonly Dictionary<string, string> StageIDs = new Dictionary<string,string> {
-            { "Jellyfish Fields", "SlideHouse" },
-            { "The Flying Dutchmans Ship", "Shanty" },
-            { "Rooftop Rumble", "Rooftop" },
-            { "The Dump", "Trash" },
-            { "The Loud House", "Loud" },
+            { "CatDogs House", "House" },
+            { "Ghost Zone", "Zone" },
             { "Glove World", "CarnivalLofi" },
-            { "Sewers Slam", "SewersCombined" },
+            { "Harmonic Convergence", "SpiritWorld" },
             { "Irken Armada Invasion", "Armada" },
-            { "Technodrom Takedown", "Drome" },
+            { "Jellyfish Fields", "SlideHouse" },
+            { "Omashu", "Omashu" },
+            { "Powdered Toast Trouble", "DuoKitchen" },
+            { "Rooftop Rumble", "Rooftop" },
             { "Royal Woods Cemetery", "YMC" },
-            { "CatDog's House", "House" },
+            { "Sewers Slam", "SewersCombined" },
+            { "Showdown at Teeter Totter Gulch", "Playground" },
+            { "Space Madness", "DuoMadness" },
+            { "Technodrom Takedown", "Drome" },
+            { "The Dump", "Trash" },
+            { "The Flying Dutchmans Ship", "Shanty" },
+            { "The Loud House", "Loud" },
             { "Traffic Jam", "Stomp" },
             { "Western Air Temple", "Temple2" },
-            { "Wild Waterfall", "Waterfall" },
-            { "Powdered Toast Trouble", "DuoKitchen" },
-            { "Ghost Zone", "Zone" },
-            { "Harmonic Convergence", "SpiritWorld" },
-            { "Omashu", "Omashu" },
-            { "Showdown at Teeter Totter Gulch", "Playground" }
+            { "Wild Waterfall", "Waterfall" }
         };
 
         public static readonly string[] MenuIDs = { 


### PR DESCRIPTION
Use the user friendly official stage name instead of the id name for the stage music.

This PR will convert the existing folders to the new format, and handle 3 specific cases.

This PR addresses multiple cases:

1. No folders have been created at all
1. Folders exist but they are the old format
1. Folders exist and some are the new format, some are the old format

I have tested all 3 cases myself, but it would be nice if someone else could test it as well before I make a new release.