### PR TITLE
Add option to skip OnlineMenu music if folder is empty

### DIFF
--- a/NickCustomMusicMod.csproj
+++ b/NickCustomMusicMod.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.3.2</Version>
-    <AssemblyVersion>1.3.2.0</AssemblyVersion>
-    <FileVersion>1.3.2.0</FileVersion>
+    <Version>1.3.3</Version>
+    <AssemblyVersion>1.3.3.0</AssemblyVersion>
+    <FileVersion>1.3.3.0</FileVersion>
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/Patches/GameMusicBank_GetMusic.cs
+++ b/Patches/GameMusicBank_GetMusic.cs
@@ -23,6 +23,9 @@ namespace NickCustomMusicMod.Patches
         static bool Prefix(ref string id)
 		{
 			var config = Plugin.Instance.Config;
+
+			Plugin.LogDebug($"GameMusicBank_GetMusic id: {id} previousMusicID: {Plugin.previousMusicID}");
+
 			Plugin.previousMusicID = id;
 
 			// Get a random song for this stage / menu

--- a/Patches/MusicChanger_StartMusic.cs
+++ b/Patches/MusicChanger_StartMusic.cs
@@ -37,7 +37,27 @@ namespace NickCustomMusicMod.Patches
 					return false;
 				}
 			}
-			
+
+			Plugin.LogDebug($"MusicChanger_StartMusic id: {newMusicId} previousMusicID: {Plugin.previousMusicID}");
+
+			// Skip the online menu music if the setting is enabeld in the config
+			// and there are no custom songs for the OnlineMenu
+			if (Plugin.Instance.skipOnlineMenuMusicIfEmpty.Value && newMusicId.Equals("OnlineMenu")) {
+				if (CustomMusicManager.songDictionaries.TryGetValue(newMusicId, out var dict) && dict.Keys.Count == 0)
+				{
+					if (!Plugin.previousMusicID.Equals("MainMenu"))
+                    {
+						// Switch to main menu theme if we are coming out of a match in online mode
+						newMusicId = "MainMenu";
+						Plugin.LogInfo($"No songs found for \"OnlineMenu\", and \"Skip OnlineMenu Music if Empty\" is {Plugin.Instance.skipOnlineMenuMusicIfEmpty.Value}! Changing music ID to {newMusicId}.");
+					} else
+                    {
+						Plugin.LogInfo($"No songs found for \"OnlineMenu\", and \"Skip OnlineMenu Music if Empty\" is {Plugin.Instance.skipOnlineMenuMusicIfEmpty.Value}! Current song will keep playing.");
+						return false;
+					}
+				}
+			}
+
 			Plugin.previousMusicID = newMusicId;
 
 			return true;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -14,6 +14,7 @@ namespace NickCustomMusicMod
         internal static Plugin Instance;
         internal static string previousMusicID;
         internal ConfigEntry<bool> useDefaultSongs;
+        internal ConfigEntry<bool> skipOnlineMenuMusicIfEmpty;
         private void Awake()
         {
             Logger.LogDebug($"Plugin {PluginInfo.PLUGIN_NAME} is loaded!");
@@ -28,6 +29,7 @@ namespace NickCustomMusicMod
             var config = this.Config;
 
             useDefaultSongs = Config.Bind<bool>("Options", "Use Default Songs", false);
+            skipOnlineMenuMusicIfEmpty = Config.Bind<bool>("Options", "Skip OnlineMenu Music if Empty", true);
 
             config.SettingChanged += OnConfigSettingChanged;
 

--- a/PluginInfo.cs
+++ b/PluginInfo.cs
@@ -8,6 +8,6 @@ namespace NickCustomMusicMod
     {
         public const string PLUGIN_GUID = "megalon.nick_custom_music_mod";
         public const string PLUGIN_NAME = "NickCustomMusicMod";
-        public const string PLUGIN_VERSION = "1.3.2";
+        public const string PLUGIN_VERSION = "1.3.3";
     }
 }


### PR DESCRIPTION
This adds an option to skip the OnlineMenu music if the OnlineMenu folder is empty.

`Skip OnlineMenu Music if Empty` default is `true`